### PR TITLE
Move VAPID keys to environment variables and improve security

### DIFF
--- a/amplify/functions/push-notifications/index.ts
+++ b/amplify/functions/push-notifications/index.ts
@@ -2,19 +2,21 @@ import type { Handler } from "aws-lambda";
 // @ts-ignore: No type definitions for 'web-push'
 import webpush from "web-push";
 
-// VAPID keys for Web Push API
-const vapidKeys = {
-  publicKey:
-    "BIYhxDOAqmZg6VijBF03tQjjLDBGnZO6plp45i4XQJbgY8EjudgnVYip5_pdbnHCZAmMXo74dstdV01n1DH0Oqk",
-  privateKey: "CQ-R-YQ_453n-_he_1HCxn5b2P68xgahZK8ovVDWQZI",
-};
+// VAPID keys for Web Push API - loaded from environment variables
+const vapidPublicKey = process.env.VAPID_PUBLIC_KEY;
+const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY;
+const vapidEmail = process.env.VAPID_EMAIL || "mailto:noreply@example.com";
 
-// Set VAPID details
-webpush.setVapidDetails(
-  "mailto:noreply@cloudles.gr", // Replace with your email
-  vapidKeys.publicKey,
-  vapidKeys.privateKey,
-);
+if (!vapidPublicKey || !vapidPrivateKey) {
+  console.warn("VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY environment variables are required for push notifications");
+} else {
+  webpush.setVapidDetails(vapidEmail, vapidPublicKey, vapidPrivateKey);
+}
+
+const vapidKeys = {
+  publicKey: vapidPublicKey ?? "",
+  privateKey: vapidPrivateKey ?? "",
+};
 
 interface PushMessage {
   title: string;

--- a/app/api/push-notifications/route.ts
+++ b/app/api/push-notifications/route.ts
@@ -1,19 +1,21 @@
 import { type NextRequest, NextResponse } from "next/server";
 import webpush from "web-push";
 
-// VAPID keys for Web Push API
-const vapidKeys = {
-  publicKey:
-    "BIYhxDOAqmZg6VijBF03tQjjLDBGnZO6plp45i4XQJbgY8EjudgnVYip5_pdbnHCZAmMXo74dstdV01n1DH0Oqk",
-  privateKey: "CQ-R-YQ_453n-_he_1HCxn5b2P68xgahZK8ovVDWQZI",
-};
+// VAPID keys for Web Push API - loaded from environment variables
+const vapidPublicKey = process.env.VAPID_PUBLIC_KEY;
+const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY;
+const vapidEmail = process.env.VAPID_EMAIL || "mailto:noreply@example.com";
 
-// Set VAPID details
-webpush.setVapidDetails(
-  "mailto:example@example.com", // Replace with your email
-  vapidKeys.publicKey,
-  vapidKeys.privateKey,
-);
+if (!vapidPublicKey || !vapidPrivateKey) {
+  console.warn("VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY environment variables are required for push notifications");
+} else {
+  webpush.setVapidDetails(vapidEmail, vapidPublicKey, vapidPrivateKey);
+}
+
+const vapidKeys = {
+  publicKey: vapidPublicKey ?? "",
+  privateKey: vapidPrivateKey ?? "",
+};
 
 interface PushMessage {
   title: string;

--- a/client/components/ErrorBoundary.tsx
+++ b/client/components/ErrorBoundary.tsx
@@ -43,6 +43,7 @@ class ErrorBoundary extends Component<Props, State> {
             </p>
             <button
               type='button'
+              onClick={() => window.location.reload()}
               className='px-6 py-3 bg-cyan-400 hover:bg-cyan-500 text-white rounded-md transition-colors duration-300 font-medium'
             >
               Refresh Page

--- a/server/routes/contact.ts
+++ b/server/routes/contact.ts
@@ -149,9 +149,9 @@ export const handleContactForm = async (req: Request, res: Response) => {
     // Verify reCAPTCHA
     let recaptchaSecret = process.env.RECAPTCHA_SECRET_KEY
 
-    // Use test keys in development/test environment
-    if (process.env.NODE_ENV !== 'production' || !recaptchaSecret) {
-      // Google's test reCAPTCHA secret key - always validates successfully
+    // Use test keys only in non-production environments when no key is configured
+    if (process.env.NODE_ENV !== 'production' && !recaptchaSecret) {
+      // Google's test reCAPTCHA secret key - always validates successfully (dev only)
       recaptchaSecret = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
     }
 

--- a/server/routes/push-notifications.ts
+++ b/server/routes/push-notifications.ts
@@ -8,19 +8,22 @@ const HTTP_STATUS = {
   INTERNAL_SERVER_ERROR: 500,
 } as const
 
-// VAPID keys for Web Push API
-const vapidKeys = {
-  publicKey:
-    'BIYhxDOAqmZg6VijBF03tQjjLDBGnZO6plp45i4XQJbgY8EjudgnVYip5_pdbnHCZAmMXo74dstdV01n1DH0Oqk',
-  privateKey: 'CQ-R-YQ_453n-_he_1HCxn5b2P68xgahZK8ovVDWQZI',
+// VAPID keys for Web Push API - loaded from environment variables
+const vapidPublicKey = process.env.VAPID_PUBLIC_KEY
+const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY
+const vapidEmail = process.env.VAPID_EMAIL || 'mailto:noreply@example.com'
+
+if (!vapidPublicKey || !vapidPrivateKey) {
+  console.warn('VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY environment variables are required for push notifications')
+} else {
+  // Set VAPID details
+  webpush.setVapidDetails(vapidEmail, vapidPublicKey, vapidPrivateKey)
 }
 
-// Set VAPID details
-webpush.setVapidDetails(
-  'mailto:noreply@cloudles.gr', // Replace with your email
-  vapidKeys.publicKey,
-  vapidKeys.privateKey,
-)
+const vapidKeys = {
+  publicKey: vapidPublicKey ?? '',
+  privateKey: vapidPrivateKey ?? '',
+}
 
 interface PushMessage {
   title: string


### PR DESCRIPTION
## Summary
This PR improves security and configuration management by moving hardcoded VAPID keys and email addresses to environment variables across all push notification implementations. It also includes minor bug fixes for reCAPTCHA validation logic and error boundary functionality.

## Key Changes
- **VAPID Configuration**: Migrated hardcoded VAPID public/private keys and email addresses to environment variables (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_EMAIL`) across three files:
  - `server/routes/push-notifications.ts`
  - `amplify/functions/push-notifications/index.ts`
  - `app/api/push-notifications/route.ts`
  
- **Environment Variable Validation**: Added validation to warn when required VAPID environment variables are missing, with graceful fallback to empty strings

- **reCAPTCHA Logic Fix**: Updated reCAPTCHA test key fallback logic in `server/routes/contact.ts` to only use test keys in non-production environments when no key is configured (changed from `||` to `&&` operator)

- **Error Boundary Enhancement**: Added missing `onClick` handler to the "Refresh Page" button in `client/components/ErrorBoundary.tsx` to actually reload the page

## Implementation Details
- VAPID email defaults to `'mailto:noreply@example.com'` if not provided
- All three push notification implementations now follow the same pattern for consistency
- The code maintains backward compatibility by using nullish coalescing (`??`) for the vapidKeys object

https://claude.ai/code/session_01G8U8asGxVmSqsTRM2zdpBh